### PR TITLE
upload iiif manifest by json file

### DIFF
--- a/system/application/views/melons/cantaloupe/upload.php
+++ b/system/application/views/melons/cantaloupe/upload.php
@@ -290,6 +290,11 @@ Other supported formats: 3gp, aif, flv, mov, mpg, oga, tif, webm<br />
 		<small>IPTC or ID3 fields embedded in the file will auto-populate during upload</small>
 	</td></tr>
 	<tr id="metadata_rows_parent"><td class="field"></td><td><div id="metadata_rows"></div></td></tr>
+	<tr><td>IIIF</td><td>
+		<div class="checkbox">
+			<label><input type="checkbox" id="media_file_url_iiif" name="iiif-url" /> Is IIIF Manifest</label>	
+		</div>
+	</td></tr>
 	<tr><td class="field">Choose file</td><td>
 		<!-- <input type="file" name="source_file" /> -->
 		<label class="btn btn-grey" for="my-file-selector">


### PR DESCRIPTION
This PR adds functionality to upload a IIIF manifest as a file by:

- Adding a checkbox to the `Upload Media Files` form
- Leveraging existing work on IIIF manifests by using the same `id` and `name` of the form field