### PR TITLE
Two fixes for iiif-integration

### DIFF
--- a/system/application/controllers/api.php
+++ b/system/application/controllers/api.php
@@ -268,7 +268,7 @@ Class Api extends CI_Controller {
 	* and other metadata from the iiif json itself.
 	**/
 	private function _load_iiif_data(){
-		if (strpos($this->data['scalar:url'], '?iiif-manifest=1') > -1){
+		if (isset($this->data['scalar:url']) && strpos($this->data['scalar:url'], '?iiif-manifest=1') > -1){
 			$iiif_metadata_array = $this->_get_IIIF_metadata($this->data['scalar:url']);
 			if($iiif_metadata_array !== false){
 				foreach ($iiif_metadata_array as $key => $value){ 

--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5538,6 +5538,8 @@ function YouTubeGetID(url){
 
 			this.parentView.layoutMediaObject();
 			this.parentView.removeLoadingMessage();
+      // make sure mirador doesn't overflow its bounds
+      $('.mirador-viewer').css('max-height', $('.mediaContainer').css('max-height'));
 
 			return;
 		}

--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5539,7 +5539,7 @@ function YouTubeGetID(url){
 			this.parentView.layoutMediaObject();
 			this.parentView.removeLoadingMessage();
       // make sure mirador doesn't overflow its bounds
-      $('.mirador-viewer').css('max-height', $('.mediaContainer').css('max-height'));
+      $('.mirador-viewer', this.mediaObject).css('max-height', $(this.parentView.mediaContainer).css('max-height'));
 
 			return;
 		}


### PR DESCRIPTION
This PR resolves atgu-2574 by:

- Setting the `max-height` css property of the `mirador-viewer` to the `max-height` of the `mediaContainer`
- Including a iiif integration bug fix that I noticed in upstream