### PR TITLE
Mirador fix

### DIFF
--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5521,26 +5521,23 @@ function YouTubeGetID(url){
 		this.isLiquid = true;					// media will expand to fill available space
 
 		/**
-		 * Creates the video media object.
+		 * Creates the mirador media object.
 		 */
 		jQuery.MiradorObjectView.prototype.createObject = function() {
 
-			var approot = $('link#approot').attr('href');
-			let m3Instances = $('.m3');
-			let miradorId = m3Instances.length;
-			this.mediaObject = $( `<div class="mediaObject m3" id="mirador-${miradorId}"></div>`).appendTo( this.parentView.mediaContainer );
+			this.mediaObject = $( `<div class="mediaObject" id="mirador-${me.model.id}"></div>`).appendTo( this.parentView.mediaContainer );
       
-      var miradorInstance = Mirador.viewer({
-        id: `mirador-${miradorId}`,
-        windows: [
-          { manifestId: this.model.node.current.sourceFile }
-        ]
-      });
+			var miradorInstance = Mirador.viewer({
+				id: `mirador-${me.model.id}`,
+				windows: [
+					{ manifestId: this.model.node.current.sourceFile }
+				]
+			});
 
 			this.parentView.layoutMediaObject();
 			this.parentView.removeLoadingMessage();
-      // make sure mirador doesn't overflow its bounds
-      $('.mirador-viewer', this.mediaObject).css('max-height', $(this.parentView.mediaContainer).css('max-height'));
+			// make sure mirador doesn't overflow its bounds
+			$('.mirador-viewer', this.mediaObject).css('max-height', $(this.parentView.mediaContainer).css('max-height'));
 
 			return;
 		}
@@ -5559,8 +5556,8 @@ function YouTubeGetID(url){
 		 * @param {Number} height		The new height of the media.
 		 */
 		jQuery.MiradorObjectView.prototype.resize = function(width, height) {
-			$('.m3').width(Math.round(width));
-			$('.m3').height(Math.round(height));
+			$(`#mirador-${me.model.id}`).width(Math.round(width));
+			$(`#mirador-${me.model.id}`).height(Math.round(height));
 		}
 
 	}

--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5526,11 +5526,12 @@ function YouTubeGetID(url){
 		jQuery.MiradorObjectView.prototype.createObject = function() {
 
 			var approot = $('link#approot').attr('href');
-
-			this.mediaObject = $( '<div class="mediaObject" id="mirador"></div>' ).appendTo( this.parentView.mediaContainer );
+			let m3Instances = $('.m3');
+			let miradorId = m3Instances.length;
+			this.mediaObject = $( `<div class="mediaObject m3" id="mirador-${miradorId}"></div>`).appendTo( this.parentView.mediaContainer );
       
       var miradorInstance = Mirador.viewer({
-        id: 'mirador',
+        id: `${mirador-id}`,
         windows: [
           { manifestId: this.model.node.current.sourceFile }
         ]
@@ -5558,8 +5559,8 @@ function YouTubeGetID(url){
 		 * @param {Number} height		The new height of the media.
 		 */
 		jQuery.MiradorObjectView.prototype.resize = function(width, height) {
-			$('#mirador').width(Math.round(width));
-			$('#mirador').height(Math.round(height));
+			$('.m3').width(Math.round(width));
+			$('.m3').height(Math.round(height));
 		}
 
 	}

--- a/system/application/views/widgets/mediaelement/jquery.mediaelement.js
+++ b/system/application/views/widgets/mediaelement/jquery.mediaelement.js
@@ -5531,7 +5531,7 @@ function YouTubeGetID(url){
 			this.mediaObject = $( `<div class="mediaObject m3" id="mirador-${miradorId}"></div>`).appendTo( this.parentView.mediaContainer );
       
       var miradorInstance = Mirador.viewer({
-        id: `${mirador-id}`,
+        id: `mirador-${miradorId}`,
         windows: [
           { manifestId: this.model.node.current.sourceFile }
         ]


### PR DESCRIPTION
This PR resolves a bug found by the upstream scalar team, where if you instantiate more than one mirador instance on a page, it would result in buggy behavior. I surmised that this is because each instance is sharing the same id. It is resolved by:

- Checking for the number of mirador instances on the page when one is instantiated
- Building a miradorId based on that number
- Using the miradorId to uniquely identify each mirador instance in the media object div, as well as the Mirador viewer